### PR TITLE
adding sys import to resolve error in ServiceTask

### DIFF
--- a/pi_trees_ros/src/pi_trees_ros/pi_trees_ros.py
+++ b/pi_trees_ros/src/pi_trees_ros/pi_trees_ros.py
@@ -25,6 +25,7 @@ import rospy
 import actionlib
 from actionlib_msgs.msg import GoalStatus
 from pi_trees_lib.pi_trees_lib import *
+import sys
 
 class MonitorTask(Task):
     """


### PR DESCRIPTION
In the try/except block in the ServiceTask class it calls `sys.exc_info()`. This throws an error since sys is not imported. This PR imports sys into py_trees_ros.py
