### PR TITLE
typo for waittask

### DIFF
--- a/pi_trees_lib/src/pi_trees_lib/pi_trees_lib.py
+++ b/pi_trees_lib/src/pi_trees_lib/pi_trees_lib.py
@@ -570,7 +570,7 @@ class CallbackTask(Task):
     def reset(self):
         self.status = None
         
-def WaitTask(Task):
+class WaitTask(Task):
     """
         This is a *blocking* wait task.  The interval argument is in seconds.
     """


### PR DESCRIPTION
fix a typo.

as an aside, I'm not sure how useful a blocking wait task is since it will block for every tick of the tree. It kind of needs a status flag like simpleactiontask so that it blocks for x number of seconds then continues on for subsequent ticks.
